### PR TITLE
feat: add node flag

### DIFF
--- a/builder/flags.go
+++ b/builder/flags.go
@@ -9,6 +9,7 @@ const (
 	FlagIgnoreUnexported
 	FlagZeroValueOnPtrInconsistency
 	FlagSkipCopySameType
+	FlagNode
 )
 
 type ConversionFlags map[ConversionFlag]bool

--- a/builder/struct.go
+++ b/builder/struct.go
@@ -146,6 +146,10 @@ func (*Struct) Build(gen Generator, ctx *MethodContext, sourceID *xtype.JenID, s
 		stmt = append(stmt, jen.Id("_").Op("=").Add(sourceID.Code.Clone()))
 	}
 
+	if ctx.Flags.Has(FlagNode) {
+		stmt = append(stmt, jen.Id(name).Dot("InitId").Call())
+	}
+
 	return stmt, xtype.VariableID(jen.Id(name)), nil
 }
 

--- a/comments/parse_docs.go
+++ b/comments/parse_docs.go
@@ -330,6 +330,9 @@ func parseMethodComment(comment string) (Method, error) {
 				}
 				m.Flags.Set(builder.FlagWrapErrors)
 				continue
+			case "node":
+				m.Flags.Set(builder.FlagNode)
+				continue
 			}
 			return m, fmt.Errorf("unknown %s comment: %s", prefix, line)
 		}


### PR DESCRIPTION
`// goverter:node` is used for telling converter to call `.InitId()` on target struct before returning. So we don't have to call it every time we convert from entity to GQL DTO

Example:
```go
// goverter:converter
type Converter interface {
	// goverter:node
	ConvertFooBar(source Foo) Bar
}
```

will generate
```go
type ConverterImpl struct{}

func (c *ConverterImpl) ConvertFooBar(source converter.Foo) converter.Bar {
	var exampleBar converter.Bar
	exampleBar.A = source.A
	exampleBar.B = source.B
	exampleBar.InitId()
	return exampleBar
}
```

and also work with pointer
```go
func (c *ConverterImpl) ConvertPointerFooBar(source *converter.Foo) *converter.Bar {
	var pExampleBar *converter.Bar
	if source != nil {
		var exampleBar converter.Bar
		exampleBar.A = (*source).A
		exampleBar.B = (*source).B
		exampleBar.InitId()
		pExampleBar = &exampleBar
	}
	return pExampleBar
}
```